### PR TITLE
Add some alerting rules for the DC/OS storage service

### DIFF
--- a/rules/dss.yml
+++ b/rules/dss.yml
@@ -1,0 +1,19 @@
+groups:
+- name: DSS
+  rules:
+  - alert: Failover
+    # If the uptime of the service is less than 300 s it likely failed over.
+    expr: dss_sched_uptime < 300
+    labels:
+      severity: warning
+    annotations:
+      summary: DC/OS storage service failed over
+  - alert: Disconnected
+    # The default heartbeat interval in Mesos is 1/(15 s) = 0.067/s.
+    expr: rate(dss_sched_events_heartbeat_process_count[5m]) < 0.05
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: DC/OS storage service has problem connecting to master
+


### PR DESCRIPTION
This patch add a failover and a disconnection alert for the DC/OS
storage service. We aggregate quantities over 5 min intervals to allow
for degraded sampling rates (currently approximately 1/10 s).